### PR TITLE
Remove default div wrapping from Description and Reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ js/*~
 ./ndex-webapp-config.js
 /bower_components
 /app/bower_components
-
+.tmp

--- a/app/views/directives/bulkEditNetworkPropertyModal.html
+++ b/app/views/directives/bulkEditNetworkPropertyModal.html
@@ -21,7 +21,7 @@
                             ta-toolbar-group-class="btn-group btn-group-xs"
                             ta-toolbar-button-class="btn btn-default"
                             ta-toolbar-button-active-class="active"
-                            ta-default-wrap="div"
+                            ta-default-wrap="null"
                             ng-model='network.description'>
                     </text-angular>
                 </div>
@@ -37,7 +37,7 @@
                             ta-toolbar-group-class="btn-group btn-group-xs"
                             ta-toolbar-button-class="btn btn-default"
                             ta-toolbar-button-active-class="active"
-                            ta-default-wrap="div"
+                            ta-default-wrap="null"
                             ng-model='network.reference'>
                     </text-angular>
                 </div>

--- a/app/views/directives/createNetworkSetModal.html
+++ b/app/views/directives/createNetworkSetModal.html
@@ -27,7 +27,7 @@
                             ta-toolbar-group-class="btn-group btn-group-xs"
                             ta-toolbar-button-class="btn btn-default"
                             ta-toolbar-button-active-class="active"
-                            ta-default-wrap="div"
+                            ta-default-wrap="null"
                             ng-model='networkSet.description'>
                     </text-angular>
                 </div>
@@ -42,7 +42,7 @@
                             ta-toolbar-group-class="btn-group btn-group-xs"
                             ta-toolbar-button-class="btn btn-default"
                             ta-toolbar-button-active-class="active"
-                            ta-default-wrap="div"
+                            ta-default-wrap="null"
                             ng-model='networkSet.properties.reference'>
                     </text-angular>
                 </div>

--- a/app/views/directives/editNetworkSetModal.html
+++ b/app/views/directives/editNetworkSetModal.html
@@ -27,7 +27,7 @@
                             ta-toolbar-group-class="btn-group btn-group-xs"
                             ta-toolbar-button-class="btn btn-default"
                             ta-toolbar-button-active-class="active"
-                            ta-default-wrap="div"
+                            ta-default-wrap="null"
                             ng-model='networkSet.description'>
                     </text-angular>
                 </div>
@@ -41,7 +41,7 @@
                             ta-toolbar-group-class="btn-group btn-group-xs"
                             ta-toolbar-button-class="btn btn-default"
                             ta-toolbar-button-active-class="active"
-                            ta-default-wrap="div"
+                            ta-default-wrap="null"
                             ng-model='networkSet.properties.reference'>
                     </text-angular>
                 </div>

--- a/app/views/directives/editNetworkSummaryModal.html
+++ b/app/views/directives/editNetworkSummaryModal.html
@@ -23,7 +23,7 @@
                       ta-toolbar-group-class="btn-group btn-group-xs"
                       ta-toolbar-button-class="btn btn-default"
                       ta-toolbar-button-active-class="active"
-                      ta-default-wrap="div"
+                      ta-default-wrap="null"
                       ng-model='network.description'>
                   </text-angular>
               </div>
@@ -37,7 +37,7 @@
                         ta-toolbar-group-class="btn-group btn-group-xs"
                         ta-toolbar-button-class="btn btn-default"
                         ta-toolbar-button-active-class="active"
-                        ta-default-wrap="div"
+                        ta-default-wrap="null"
                         ng-model='network.reference'>
                   </text-angular>
               </div>

--- a/app/views/directives/editUserModal.html
+++ b/app/views/directives/editUserModal.html
@@ -98,7 +98,7 @@
                      ta-toolbar-group-class="btn-group btn-group-xs"
                      ta-toolbar-button-class="btn btn-default"
                      ta-toolbar-button-active-class="active"
-                     ta-default-wrap="div"
+                     ta-default-wrap="null"
                      ng-model='user.description'>
                   </text-angular>
               </div>

--- a/app/views/partials/doiNetworkProperties.html
+++ b/app/views/partials/doiNetworkProperties.html
@@ -85,7 +85,7 @@
                             ta-toolbar-group-class="btn-group btn-group-xs"
                             ta-toolbar-button-class="btn btn-default"
                             ta-toolbar-button-active-class="active"
-                            ta-default-wrap="div"
+                            ta-default-wrap="null"
                             ng-change="editor.updateScore()"
                             ng-model='mainProperty.description'>
                     </text-angular>
@@ -142,7 +142,7 @@
                                 ta-toolbar-group-class="btn-group btn-group-xs"
                                 ta-toolbar-button-class="btn btn-default"
                                 ta-toolbar-button-active-class="active"
-                                ta-default-wrap="div"
+                                ta-default-wrap="null"
                                 ng-change="editor.updateScore()"
                                 ng-model='mainProperty.reference'>
                         </text-angular>

--- a/app/views/partials/mainNetworkProperties.html
+++ b/app/views/partials/mainNetworkProperties.html
@@ -53,7 +53,7 @@
                             ta-toolbar-group-class="btn-group btn-group-xs"
                             ta-toolbar-button-class="btn btn-default"
                             ta-toolbar-button-active-class="active"
-                            ta-default-wrap="div"
+                            ta-default-wrap="null"
                             ng-change="editor.updateScore()"
                             ng-model='mainProperty.description'>
                     </text-angular>
@@ -254,7 +254,7 @@
                             ta-toolbar-group-class="btn-group btn-group-xs"
                             ta-toolbar-button-class="btn btn-default"
                             ta-toolbar-button-active-class="active"
-                            ta-default-wrap="div"
+                            ta-default-wrap="null"
                             ng-change="editor.updateScore()"
                             ng-model='mainProperty.reference'>
                     </text-angular>


### PR DESCRIPTION
This only works for newly created instances. All current descriptions and references will keep the wrapping <div> tags. Had to make a similar change in many places, perhaps this should be a component for easier modification.