### PR TITLE
Vr

### DIFF
--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -1483,7 +1483,8 @@ ndexApp.controller('mainController', [ 'ndexService', 'ndexUtility', 'sharedProp
                 var title   = mainItem.title;
                 var content =
                     window.ndexSettings.landingPageConfigServer + '/'+ mainItem.content;
-                var href    = mainItem.href;
+
+                var href = (mainItem.href) ? mainItem.href : null;
 
                 mainContent.push({
                     'title': title,

--- a/app/scripts/controllers/network-controller.js
+++ b/app/scripts/controllers/network-controller.js
@@ -121,11 +121,6 @@ ndexApp.controller('networkController',
                     .attr('data-original-title', message)
                     .tooltip('show');
             }
-            function setTooltipOnSetSampleButtonId(message) {
-                $('#setSampleButtonId').tooltip('hide')
-                    .attr('data-original-title', message)
-                    .tooltip('show');
-            }
             $scope.changeTitle = function() {
                 setTooltip('Copy network share URL to clipboard');
             };
@@ -210,14 +205,6 @@ ndexApp.controller('networkController',
                     .tooltip('show');
             };
 
-            $scope.changeNodesEdgesTabTitle = function() {
-                var title = networkController.tabs[1].disabled ?
-                    'Select nodes or edges in the graph to enable this tab' : '';
-
-                $('#nodesEdgesTabId').tooltip('hide')
-                    .attr('data-original-title', title)
-                    .tooltip('show');
-            };
 
             $scope.isEdgesAndNodesTabDisabled = function() {
                 return networkController.tabs[1].disabled ? 'disabled' : 'enabled';
@@ -297,6 +284,10 @@ ndexApp.controller('networkController',
             networkController.tabs    = new Array(4);
             networkController.tabs[0] = {'heading': 'Network Info',   'active': true};
             networkController.tabs[1] = {'heading': 'Nodes/Edges',    'active': false, 'disabled': true};
+
+            $scope.setToolTipOnNodesAndEdgesTab = function() {
+                $scope.nodesAndEdgesTabTitle = networkController.tabs[1].disabled ? 'Select nodes or edges in the graph to enable this tab' : '';
+            };
 
 
             /* TODO: for 2.4.1, remove all networkController.tabs[2] since we do not support provevance any longer  */
@@ -3186,27 +3177,25 @@ ndexApp.controller('networkController',
                 if ($scope.showSetSampleButton) {
 
                     if (edgeCount > 1000) {
-                        $scope.showSetSampleButtonEnabled = false;
 
-                        setTooltipOnSetSampleButtonId(
-                            'Cannot set sample for query results with more than 1000 edges');
+                        $scope.showSetSampleButtonEnabled = false;
+                        $scope.setSampleButtonToolTip = 'Cannot set sample for query results with more than 1000 edges';
 
                     } else if (networkController.previousNetwork.edgeCount < $scope.noOfEdgesToShowSetSampleButton) {
-                        setTooltipOnSetSampleButtonId(
-                            'Cannot set sample for networks with less than ' + $scope.noOfEdgesToShowSetSampleButton +  ' edges');
 
                         $scope.showSetSampleButtonEnabled = false;
+                        $scope.setSampleButtonToolTip =
+                            'Cannot set sample for networks with less than ' + $scope.noOfEdgesToShowSetSampleButton +  ' edges';
 
                     } else if ((networkController.previousNetwork.edgeCount <= 12000) && networkController.previousNetwork.hasLayout) {
-                        setTooltipOnSetSampleButtonId('This feature is not yet implemented');
 
                         $scope.showSetSampleButtonEnabled = false;
+                        $scope.setSampleButtonToolTip = 'This feature is not yet implemented';
 
                     }
                     else {
-                            setTooltipOnSetSampleButtonId('Set this query as network sample ');
-
                             $scope.showSetSampleButtonEnabled = true;
+                            $scope.setSampleButtonToolTip = 'Set this query as network sample ';
                         }
                     }
 

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -54,9 +54,9 @@
                                      <ng-include src="item.content"></ng-include>
                                  </div>
 
-                                 <div ng-show='item.href'>
-                                    <a ng-href="{{item.href}}" target="_blank" style="text-align: center">>> Learn more ...</a>
-                                 </div>
+                                 <a ng-show='item.href' ng-href="{{item.href}}" target="_blank" style="text-align: center">
+                                     >> Learn more ...
+                                 </a>
                             </div>
 
                         </div>

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -53,7 +53,10 @@
                                  <div class="mainAreaLandingPage" style="height: 506px;">
                                      <ng-include src="item.content"></ng-include>
                                  </div>
-                                 <a ng-href="{{item.href}}" target="_blank" style="text-align: center">>> Learn more ...</a>
+
+                                 <div ng-show='item.href'>
+                                    <a ng-href="{{item.href}}" target="_blank" style="text-align: center">>> Learn more ...</a>
+                                 </div>
                             </div>
 
                         </div>

--- a/app/views/network.html
+++ b/app/views/network.html
@@ -468,8 +468,12 @@
                 </tab>
 
                 <!-- node/edge tab -->
-                <tab id='nodesEdgesTabId' class='{{isEdgesAndNodesTabDisabled()}}' active="networkController.tabs[1].active"
-                     data-toggle="tooltip" ng-mouseover="changeNodesEdgesTabTitle()" data-placement="bottom" title="">
+                <tab id='nodesEdgesTabId' class='{{isEdgesAndNodesTabDisabled()}}'
+                     active="networkController.tabs[1].active"
+                     tooltip="{{nodesAndEdgesTabTitle}}"
+                     ng-mouseenter="setToolTipOnNodesAndEdgesTab()"
+                     ng-init="setToolTips()"
+                     tooltip-placement="bottom">
                     <tab-heading>{{ networkController.tabs[1].heading }}</tab-heading>
 
                     <div>
@@ -803,10 +807,9 @@
                 {{buttonLabel}}
             </button>
 
-            <button id="setSampleButtonId"
-                    ng-show="showSetSampleButton"
-                    data-toggle="tooltip"
-                    title=""
+            <button ng-show="showSetSampleButton"
+                    tooltip="{{setSampleButtonToolTip}}"
+                    ng-init="setToolTips()"
                     ng-class="showSetSampleButtonEnabled ? 'actionsLabel btn btn-primary' : 'actionsLabelDisabled-btn btn btn-primary'"
                     ng-click="networkController.setSampleFromQuery()" >
                 Set Sample

--- a/app/views/network.html
+++ b/app/views/network.html
@@ -937,7 +937,7 @@
                 </span>
 
 
-                <span ng-if="(isDOIPending() || isDOIAssigned()) && !isNetworkCertified()">
+                <span ng-if="networkController.isAdmin && (isDOIPending() || isDOIAssigned()) && !isNetworkCertified() ">
 
                     <reference-for-certification
                         network-controller='networkController'


### PR DESCRIPTION
The following issues resolved:

    NWA-344 Set Sample tooltip message clutters network view page,
    NWA-347 "Add Reference" button appears on network that the signed in user doesn't own,
    NWA-313 Node/Edge tab on network view page is buggy, and
    NWA-370 Wrong tooltip was displayed when I selected an edge in a query result

Also, at Rudi's request, we now show Learn more link only if href is present in element of main.json config file.