### PR TITLE
This resolves NWA-374 Issue with @context.

### DIFF
--- a/app/scripts/controllers/network-controller.js
+++ b/app/scripts/controllers/network-controller.js
@@ -483,7 +483,7 @@ ndexApp.controller('networkController',
                     return attributeValue;
                 }
 
-                var prefix = splitString[0].toLowerCase();
+                var prefix = splitString[0];
                 var value  = (splitString.length === 3) ? (splitString[1] + ':' + splitString[2]) : splitString[1];
                 var URI;
 


### PR DESCRIPTION
In the past, we compared prefixes of attributes with the keys of @context in case-insensitive manner.
To do so,
1) we lower-cased keys of @contex in getContextAspectFromNiceCX() and populated networkController.context
2) we lower-cased prefix of attribute in getStringAttributeValue() and checked if this
lower-cased prefix was in networkController.context

Recently we decided to make attribute prefixes case-sensitive, so we
removed code in getStringAttributeValue() that lower-cased keys.

Now we are removing code that lower-cases attribute prefix.