### PR TITLE
This commit resolves NWA-373 Tooltips on 'set network sample', 'upgra…

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -44,7 +44,7 @@
     <script src="bower_components/angular-route/angular-route.js"></script>
     <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
     <script src="bower_components/angular-touch/angular-touch.js"></script>
-    <script src="bower_components/cytoscape/dist/cytoscape.js"></script>
+    <script src="bower_components/cytoscape/dist/cytoscape.umd.js"></script>
     <script src="bower_components/ev-emitter/ev-emitter.js"></script>
     <script src="bower_components/imagesloaded/imagesloaded.js"></script>
     <script src="bower_components/qtip2/jquery.qtip.js"></script>

--- a/app/scripts/controllers/network-controller.js
+++ b/app/scripts/controllers/network-controller.js
@@ -177,24 +177,6 @@ ndexApp.controller('networkController',
                 return (isVisibility && isAccessKey);
             };
 
-            $scope.changeShareButtonTitle = function() {
-                $('#shareButtonId').tooltip('hide')
-                    .attr('data-original-title', $scope.shareTitle)
-                    .tooltip('show');
-            };
-
-            $scope.changeEditButtonTitle = function() {
-                $('#editButtonId').tooltip('hide')
-                    .attr('data-original-title', $scope.editPropertiesButtonTitle)
-                    .tooltip('show');
-            };
-
-            $scope.changeRequestDOITitle = function() {
-                $('#requestDOIId').tooltip('hide')
-                    .attr('data-original-title', $scope.requestDOITitle)
-                    .tooltip('show');
-            };
-
             $scope.changeReadOnlyButtonTitle = function() {
                 var title =
                     networkController.hasMultipleSubNetworks() ?
@@ -230,36 +212,6 @@ ndexApp.controller('networkController',
                 }
             };
 
-
-            $scope.changeExportNetworkTitle  = function() {
-                $('#exportNetworkId').tooltip('hide')
-                    .attr('data-original-title', $scope.exportTitle)
-                    .tooltip('show');
-            };
-
-            $scope.changeUpgradePermissionTitle  = function() {
-                $('#upgradePermissionTitleId').tooltip('hide')
-                    .attr('data-original-title', $scope.upgradePermissionTitle)
-                    .tooltip('show');
-            };
-
-            $scope.changeSetSampleViaUUIDTitle  = function() {
-                $('#setSampleViaUUID').tooltip('hide')
-                    .attr('data-original-title', $scope.setNetworkSampleViaUUIDTitle)
-                    .tooltip('show');
-            };
-
-            $scope.changeRemoveFromMyNetworksTitle  = function() {
-                $('#removeFromMyAccountTitleId').tooltip('hide')
-                    .attr('data-original-title', $scope.removeFromMyAccountTitle)
-                    .tooltip('show');
-            };
-
-            $scope.changeDeleteNetworkTitle  = function() {
-                $('#deleteNetworkTitleId').tooltip('hide')
-                    .attr('data-original-title', $scope.deleteTitle)
-                    .tooltip('show');
-            };
 
             $scope.changeDisabledQueryTitle1 = function() {
                 $('#disabledQueryId1').tooltip('hide')
@@ -322,7 +274,7 @@ ndexApp.controller('networkController',
             $scope.requestDOITitle           = '';
             $scope.exportTitle               = '';
             $scope.upgradePermissionTitle    = '';
-            $scope.shareTitle                = '';
+            $scope.shareTitle                = 'Share this network internally or externally';
             $scope.deleteTitle               = '';
             $scope.setNetworkSampleViaUUIDTitle     = '';
             $scope.removeFromMyAccountTitle  = '';
@@ -2065,10 +2017,6 @@ ndexApp.controller('networkController',
                 }
             };
 
-            $scope.setReturnView = function(view) {
-                sharedProperties.setNetworkViewPage(view);
-            };
-
             /*
             var enableSimpleQueryElements = function () {
                 var nodes = document.getElementById('simpleQueryNetworkViewId').getElementsByTagName('*');
@@ -3731,7 +3679,7 @@ ndexApp.controller('networkController',
                 }
             };
 
-            $scope.setNetworkSampleViaUUID = function() {
+            networkController.setNetworkSampleViaUUID = function() {
                 if (!$scope.enableSetSampleViaUUID) {
                     return;
                 }
@@ -3857,7 +3805,7 @@ ndexApp.controller('networkController',
                 });
             };
 
-            $scope.removeFromMyNetworks = function() {
+            networkController.removeFromMyNetworks = function() {
                 if (!$scope.enableRemoveFromMyAccount) {
                     return;
                 }
@@ -4039,7 +3987,7 @@ ndexApp.controller('networkController',
             }
 
 
-                var setEditPropertiesTitle = function() {
+            var setEditPropertiesTitle = function() {
                 // !networkController.isAdmin || networkController.hasMultipleSubNetworks()
                 if (networkController.hasMultipleSubNetworks()) {
                     $scope.editPropertiesButtonTitle = 'This network is a Cytoscape collection and cannot be edited in NDEx';
@@ -4054,6 +4002,8 @@ ndexApp.controller('networkController',
                     $scope.editPropertiesButtonTitle += 'If you need to update this network please clone it.';
                 }  else if (networkController.readOnlyChecked) {
                     $scope.editPropertiesButtonTitle = 'Unable to edit this network: it is read-only';
+                } else {
+                    $scope.editPropertiesButtonTitle = 'Modify network properties';  // default value - Edit button is enabled
                 }
             };
 
@@ -4119,6 +4069,30 @@ ndexApp.controller('networkController',
                             displayErrorMessage(error);
                         });
                 }
+            };
+
+            $scope.isRequestingDOIEnabled = function() {
+                var enabled =
+                 networkController.isNetworkOwner && !networkController.hasMultipleSubNetworks() &&
+                    !$scope.isNetworkCertified() && !$scope.isDOIAssigned() && !$scope.isDOIPending();
+
+                return enabled;
+            };
+
+            $scope.isUpgradingPermissionsEnabled = function() {
+                var enabled =
+                    !networkController.isAdmin && !networkController.canEdit &&
+                    !networkController.hasMultipleSubNetworks() &&
+                    !$scope.isNetworkCertified() && !$scope.isDOIAssigned() && !$scope.isDOIPending();
+
+                return enabled;
+            };
+
+            $scope.isDeleteNetworkEnabled = function() {
+                var enabled =
+                    networkController.isAdmin && !networkController.readOnlyChecked;
+
+                return enabled;
             };
 
             var initialize = function () {
@@ -4714,7 +4688,7 @@ ndexApp.controller('networkController',
 
 
 
-            networkController.deletelPendingDOIRequest = function() {
+            networkController.deletePendingDOIRequest = function() {
 
                 var title = 'Delete DOI Request';
 
@@ -4741,8 +4715,10 @@ ndexApp.controller('networkController',
                         ndexService.cancelDoi(networkController.currentNetworkId,
                             function() {
                                 delete networkController.currentNetwork.doi;
+                                delete networkController.currentNetwork.isCertified;
                                 networkController.currentNetwork.isReadOnly = false;
                                 networkController.readOnlyChecked = networkController.currentNetwork.isReadOnly;
+                                setEditPropertiesTitle();
                                 ndexSpinner.stopSpinner();
                                 $modalInstance.dismiss();
                                 delete $rootScope.errors;

--- a/app/scripts/services/sharedProperties.js
+++ b/app/scripts/services/sharedProperties.js
@@ -55,14 +55,6 @@ ndexApp.service('sharedProperties', function () {
         {
             return this.selectedNetworkIDs;
         },
-        setNetworkViewPage: function(networkView)
-        {
-            this.networkView = networkView;
-        },
-        getNetworkViewPage: function()
-        {
-            return this.networkView;
-        },
         getLoggedInUserFirstAndLastNames: function () {
             if ( window.currentNdexUser != null) {
                 return window.currentNdexUser.firstName + " " + window.currentNdexUser.lastName;

--- a/app/scripts/ui-service.js
+++ b/app/scripts/ui-service.js
@@ -784,9 +784,8 @@
                 myStyle: '@'
             },
             restrict: 'AE',
-            //template: "<button class='{{myClass}}' style='line-height: 1.428571429;' ng-click='openMe()'>Add To My Sets</button>",
 
-            template: "<button style='{{myStyle}}' class='{{myClass}}' ng-click='openMe()'>Add To My Sets</button>",
+            template: "<button class='{{myClass}}' ng-click='openMe()'>Add To My Sets</button>",
 
             controller: function($scope, $attrs, $modal, $location, ndexService, $route, $rootScope) {
                 var modalInstance;
@@ -949,9 +948,46 @@
             }
         };
     });
-    
-    
-    
+
+    uiServiceApp.directive('removeFromMyNetworks', function() {
+        return {
+            scope: {
+                controllerName: '=',
+                myClass: '@'
+            },
+            restrict: 'AE',
+
+            template: "<button class='{{myClass}}' style='white-space:nowrap;' ng-click='openMe()'>Remove from My Networks</button>",
+
+            controller: function($scope)
+            {
+                $scope.openMe = function() {
+                    $scope.controllerName.removeFromMyNetworks();
+                };
+            }
+        };
+    });
+
+    uiServiceApp.directive('setNetworkSampleViaUuid', function() {
+        return {
+            scope: {
+                controllerName: '=',
+                myClass: '@'
+            },
+            restrict: 'AE',
+
+            template: "<button class='{{myClass}}' style='white-space:nowrap;' ng-click='openMe()'>Set Network Sample</button>",
+
+            controller: function($scope)
+            {
+                $scope.openMe = function() {
+                    $scope.controllerName.setNetworkSampleViaUUID();
+                };
+            }
+        };
+    });
+
+
     // invite members modal
     //      -ndexData takes a group external id as a param
     uiServiceApp.directive('inviteMembersModal', function() {
@@ -1404,12 +1440,11 @@
             scope: {
                 ndexData: '=',
                 privileges: '=',
-                myClass: '@',
-                myStyle: '@'
+                myClass: '@'
             },
             restrict: 'E',
 
-            template: '<button style="{{myStyle}}" class="{{myClass}}" ng-click="openMe()">Upgrade Permission</button>',
+            template: '<button class="{{myClass}}" ng-click="openMe()">Upgrade Permission</button>',
 
             controller: function($scope, $modal, $route, ndexService, ndexUtility, sharedProperties, uiMisc) {
                 var modalInstance;
@@ -1984,19 +2019,45 @@
     });
     */
 
+
+
+    uiServiceApp.directive('requestDoi', function() {
+        return {
+            scope: {
+                networkController: '='
+            },
+
+            restrict: 'E',
+
+            template: '<button class="dropdown-btn" ng-click="editDOI()">Request DOI</button>',
+
+            controller: function($scope, $location)
+            {
+                $scope.editDOI = function() {
+
+                    $location.url('/properties/network/'+
+                        $scope.networkController.currentNetwork.externalId + '/' +
+                        $scope.networkController.subNetworkId + '?doi=true');
+                };
+            }
+        }
+    });
+
+
+
     // modal to export network
     uiServiceApp.directive('exportNetwork', function() {
         return {
             scope: {
-                ndexData: '=',
-                myClass: '@',
-                myStyle: '@'
+                ndexData: '='
             },
             restrict: 'E',
 
             //template: '<button style="line-height: 1.428571429;" class="{{myClass}}" ng-click="openMe()">Export</button>',
 
-            template: '<button style="{{myStyle}}" class="{{myClass}}" ng-click="openMe()">Export</button>',
+            template: '<button class="dropdown-btn" ng-click="openMe()">Export</button>',
+
+            //template: '<a  class="dropdown-btn"  type="button" href="" ng-click="openMe()" style="cursor: pointer; line-height: 1.5em; padding: 3px 20px">Export</a>',
 
             controller: function($scope, $modal, $route, ndexService, ndexUtility)
             {
@@ -3496,7 +3557,7 @@
 
             //template: '<button class="dropdown-btn" style="line-height: 1.428571429;" ng-click="openMe()">Delete</button>',
 
-            template: '<button style="{{myStyle}}" class="{{myClass}}" ng-click="openMe()">Delete</button>',
+            template: '<button class="{{myClass}}" ng-click="openMe()">Delete</button>',
 
             controller: function($scope, $modal, $location) {
 

--- a/app/styles/ndex-angular-site.css
+++ b/app/styles/ndex-angular-site.css
@@ -1358,3 +1358,10 @@ div.featuredCollectionDescriptionArea {
     text-align: left;
 }
 
+.elementOfDropDownOnNetworkPage {
+    padding: 3px 0;
+    line-height: 1.3em !important;
+}
+.disabledElementOfDropDownOnNetworkPage {
+    line-height: 1.3em !important;
+}

--- a/app/views/directives/exportNetwork.html
+++ b/app/views/directives/exportNetwork.html
@@ -41,6 +41,11 @@
             {{description}}
         </div>
 
+        <div ng-if="errors" class='text-danger' style='word-wrap:break-word'>
+            <br>
+            <strong><span style="font-size: 1.1em" ng-bind-html="errors"></span></strong>
+        </div>
+
     </div>
 
     <div class='modal-footer'>

--- a/app/views/network.html
+++ b/app/views/network.html
@@ -216,7 +216,7 @@
                                     <!-- show the Delete DOI Request link  -->
                                     &nbsp;&nbsp;&nbsp;
 
-                                    <a ng-click="networkController.deletelPendingDOIRequest()"
+                                    <a ng-click="networkController.deletePendingDOIRequest()"
                                        data-toggle="tooltip"
                                        data-placement="bottom"
                                        onmouseenter="$(this).tooltip('show')"
@@ -902,13 +902,13 @@
             </span>
 
 
-            <span id="shareButtonId" ng-show='networkController.isLoggedInUser && !networkController.isAdmin'
-                class="actionsLabelDisabled-btn btn btn-primary" ng-mouseover="changeShareButtonTitle()" title="">
+            <span ng-show='networkController.isLoggedInUser && !networkController.isAdmin'
+                class="actionsLabelDisabled-btn btn btn-primary" tooltip="{{shareTitle}}">
                 Share
             </span>
             <span ng-show='networkController.isLoggedInUser && networkController.isAdmin'>
                 <a class="actionsLabel btn btn-primary"
-                   data-toggle="tooltip" title="Share this network internally or externally"
+                   tooltip="{{shareTitle}}"
                    ng-href="{{'#/access/network/'+networkController.currentNetwork.externalId}}">
                     Share
                 </a>
@@ -918,18 +918,17 @@
             <span ng-show='networkController.isLoggedInUser'>
                 <span ng-if="(networkController.currentNetwork.doi == null) || isNetworkCertified()">
                     <a class="actionsLabel btn btn-primary"
-                       ng-show="(networkController.isAdmin || networkController.canEdit) && !networkController.readOnlyChecked
+                       ng-if="(networkController.isAdmin || networkController.canEdit) && !networkController.readOnlyChecked
                                     && !networkController.hasMultipleSubNetworks()"
-                       ng-init="setToolTips()" data-toggle="tooltip" title="Modify network properties"
-                       ng-href="{{'#/properties/network/'+networkController.currentNetwork.externalId+'/'+networkController.subNetworkId}}"
-                       ng-click="setReturnView('network/')">
+                       tooltip="{{editPropertiesButtonTitle}}"
+                       ng-href="{{'#/properties/network/'+networkController.currentNetwork.externalId+'/'+networkController.subNetworkId}}">
                         Edit
 
                     </a>
-                    <a id="editButtonId" class="actionsLabelDisabled-btn btn btn-primary"
-                       ng-show="!(networkController.isAdmin || networkController.canEdit) ||
+                    <a class="actionsLabelDisabled-btn btn btn-primary"
+                       ng-if="!(networkController.isAdmin || networkController.canEdit) ||
                        networkController.hasMultipleSubNetworks() || networkController.readOnlyChecked"
-                       ng-mouseover="changeEditButtonTitle()" title="">
+                       tooltip="{{editPropertiesButtonTitle}}">
                         Edit
                     </a>
                 </span>
@@ -949,7 +948,6 @@
 
             <span ng-show='networkController.isLoggedInUser && networkController.currentNetwork.externalId !== undefined'>
 
-
                 <div class="btn-group dropup">
 
                    <button id="moreNetworkButton" type="button" data-toggle="dropdown"
@@ -958,107 +956,90 @@
                        <span class="caret"></span>
                    </button>
 
-                    <ul class="dropdown-menu pull-right" role="menu" aria-labelledby="moreNetworkButton" >
+                    <ul class="dropdown-menu pull-right" role="menu"  aria-labelledby="moreNetworkButton" >
 
 
-                        <li id="requestDOIId" style="margin: 3px 0" class="disabled" ng-show='networkController.isLoggedInUser &&
-                                    (!networkController.isNetworkOwner || networkController.hasMultipleSubNetworks() || isNetworkCertified()
-                                    || isDOIAssigned() || isDOIPending())'
-                            ng-mouseover="changeRequestDOITitle()" title="">
-                            <a>
-                                Request DOI
+                        <li class="elementOfDropDownOnNetworkPage disabled"  ng-if="!isRequestingDOIEnabled()">
+                            <a class="disabledElementOfDropDownOnNetworkPage"
+                                tooltip="{{requestDOITitle}}">Request DOI</a>
+                        </li>
+                        <li class="elementOfDropDownOnNetworkPage" ng-if="isRequestingDOIEnabled()">
+                            <request-doi network-controller='networkController'</request-doi>
+                        </li>
+
+                        <li class="elementOfDropDownOnNetworkPage disabled"
+                            ng-if='networkController.hasMultipleSubNetworks()'>
+                            <a class="disabledElementOfDropDownOnNetworkPage"
+                                tooltip="{{exportTitle}}">Export
                             </a>
                         </li>
-                        <li style="margin: 3px 0" ng-show='networkController.isLoggedInUser &&
-                                    (networkController.isNetworkOwner && !networkController.hasMultipleSubNetworks() && !isNetworkCertified() &&
-                                     !isDOIAssigned() && !isDOIPending())'>
-
-                            <a class="dropdown-btn"
-                               ng-href="{{'#/properties/network/'+networkController.currentNetwork.externalId+'/'+networkController.subNetworkId}}?doi=true"
-                               ng-click="setReturnView('network/')">
-                                Request DOI
-                            </a>
+                        <li class="elementOfDropDownOnNetworkPage" ng-if='!networkController.hasMultipleSubNetworks()'>
+                            <export-network ndex-data='networkController.currentNetwork'></export-network>
                         </li>
 
-                        <li id="exportNetworkId" style="margin: 3px 0; line-height: 1.2em" class="disabled"
-                                ng-show='networkController.isLoggedInUser && networkController.hasMultipleSubNetworks()'
-                            ng-mouseover="changeExportNetworkTitle()" title="">
-                            <a>Export</a>
-                        </li>
-                        <li style="margin: 3px 0; line-height: 1.2em"
-                                ng-show='networkController.isLoggedInUser && !networkController.hasMultipleSubNetworks()'>
-
-                            <export-network
-                                    ndex-data='networkController.currentNetwork'
-                                    my-class="dropdown-btn"
-                                    my-style="line-height: 1.2em">
-                            </export-network>
-                        </li>
-
-                        <li style="margin: 3px 0; line-height: 1.2em" ng-show='networkController.isLoggedInUser'>
+                        <li class="elementOfDropDownOnNetworkPage">
                             <show-network-sets-modal
-                                    my-account-controller='networkController'
-                                    my-class="dropdown-btn"
-                                    my-style="line-height: 1.2em">
+                                my-account-controller='networkController'
+                                my-class="dropdown-btn">
                             </show-network-sets-modal>
-
                         </li>
 
-                         <li id="setSampleViaUUID" style="margin: 3px 0; line-height: 1.2em"
-                             ng-class="enableSetSampleViaUUID ? 'enabled' : 'disabled'"
-                             ng-mouseover="changeSetSampleViaUUIDTitle()" title=''
-                             ng-click="setNetworkSampleViaUUID()">
-                                <a>Set Network Sample </a>
+                        <li class="elementOfDropDownOnNetworkPage disabled"
+                            ng-if="!enableSetSampleViaUUID">
+                                <a class="disabledElementOfDropDownOnNetworkPage"
+                                    tooltip="{{setNetworkSampleViaUUIDTitle}}">Set Network Sample
+                                </a>
+                         </li>
+                        <li class="elementOfDropDownOnNetworkPage" ng-if="enableSetSampleViaUUID">
+                            <set-network-sample-via-uuid
+                                controller-name='networkController'
+                                my-class="dropdown-btn">
+                            </set-network-sample-via-uuid>
                         </li>
 
-
-                        <li id="upgradePermissionTitleId" style="margin: 3px 0; line-height: 1.2em" class="disabled"
-                            ng-show='networkController.isLoggedInUser &&
-                                (networkController.isAdmin || networkController.canEdit ||
-                                networkController.hasMultipleSubNetworks() || isDOIPending() || isDOIAssigned() || isNetworkCertified())'
-                            ng-mouseover="changeUpgradePermissionTitle()" title="">
-                            <a>Upgrade Permission</a>
+                        <li class="elementOfDropDownOnNetworkPage disabled"
+                            ng-if='!isUpgradingPermissionsEnabled()'>
+                                <a class="disabledElementOfDropDownOnNetworkPage"
+                                    tooltip="{{upgradePermissionTitle}}">Upgrade Permission
+                                </a>
                         </li>
-                        <li style="margin: 3px 0; line-height: 1.2em"
-                            ng-show='networkController.isLoggedInUser && !networkController.isAdmin
-                                && !networkController.canEdit && !networkController.hasMultipleSubNetworks()
-                                && !isDOIPending() && !isDOIAssigned() && !isNetworkCertified()'>
-
+                        <li class="elementOfDropDownOnNetworkPage" ng-if='isUpgradingPermissionsEnabled()'>
                             <create-request-network
                                 privileges='networkController.privilegeLevel'
                                 ndex-data='networkController.currentNetwork'
-                                my-class="dropdown-btn"
-                                my-style="line-height: 1.2em">
+                                my-class="dropdown-btn">
                             </create-request-network>
-
                         </li>
 
 
-                         <li id="removeFromMyAccountTitleId" style="margin: 3px 0; line-height: 1.2em"
-                             ng-class="enableRemoveFromMyAccount ? 'enabled' : 'disabled'"
-                             ng-mouseover="changeRemoveFromMyNetworksTitle()" title=''
-                             ng-click="removeFromMyNetworks()">
-                                <a>Remove from My Networks</a>
+
+                         <li class="elementOfDropDownOnNetworkPage disabled"
+                             ng-if="!enableRemoveFromMyAccount">
+                                <a class="disabledElementOfDropDownOnNetworkPage"
+                                   tooltip="{{removeFromMyAccountTitle}}">Remove from My Networks
+                                </a>
+                        </li>
+                        <li class="elementOfDropDownOnNetworkPage" ng-if="enableRemoveFromMyAccount">
+                            <remove-from-my-networks
+                                controller-name='networkController'
+                                my-class="dropdown-btn">
+                            </remove-from-my-networks>
                         </li>
 
-                         <li id="deleteNetworkTitleId" style="margin: 3px 0; line-height: 1.2em" class="disabled"
-                             ng-show='networkController.isLoggedInUser && !(networkController.isAdmin &&
-                                  !networkController.readOnlyChecked)'
-                             ng-mouseover="changeDeleteNetworkTitle()" title="">
-                            <a>Delete</a>
-                        </li>
-                        <li style="margin: 3px 0; line-height: 1.2em"
-                            ng-show='networkController.isLoggedInUser && networkController.isAdmin &&
-                                  !networkController.readOnlyChecked'>
 
+                        <li class="elementOfDropDownOnNetworkPage disabled"
+                            ng-if='!isDeleteNetworkEnabled()'>
+                            <a class="disabledElementOfDropDownOnNetworkPage"
+                                tooltip="{{deleteTitle}}">Delete
+                            </a>
+                        </li>
+                        <li class="elementOfDropDownOnNetworkPage" ng-if='isDeleteNetworkEnabled()'>
                             <delete-network
                                 ndex-data='networkController.currentNetwork.externalId'
-                                my-class="dropdown-btn"
-                                my-style="line-height: 1.2em">
+                                my-class="dropdown-btn">
                             </delete-network>
 
                         </li>
-
                     </ul>
 
                 </div>


### PR DESCRIPTION
…de permission' and 'remove from my networks' flicks and are not readable.

Improved menu elements of More dropup button on Network page:

1) All elements now evenly spaced, have the same style and implemented using directives.
Titles work correctly for all of the disabled menu items.

2) Edit button is fixed to always show title in case it is disabled.  Before
it only showed title first time user hovered over it.

3) Removed setReturnView - it is not needed since navigation back to Network page is done via returnToNetworkViewPage.
 Removed setNetworkViewPage() and getNetworkViewPage() - not needed for the same reason.

4) Added showing errors to exportNetwork.html modal.