### PR TITLE
This commit is for NWA-373 Tooltips on 'set network sample', 'upgrade…

### DIFF
--- a/app/scripts/controllers/network-controller.js
+++ b/app/scripts/controllers/network-controller.js
@@ -3094,6 +3094,7 @@ ndexApp.controller('networkController',
                         $scope.drawCXNetworkOnCanvasWhenViewSwitched = true;
                     } else {
                         $scope.drawCXNetworkOnCanvasWhenViewSwitched = false;
+                        $scope.switchToGraphViewButtonTitle = 'Switch to Graphic View';
                     }
 
                 } else if ((edgeCount > networkController.queryEdgeLimitToShowGraph) &&

--- a/app/views/network.html
+++ b/app/views/network.html
@@ -345,9 +345,8 @@
                                 && !networkController.hasMultipleSubNetworks() && !networkController.readOnlyChecked">
                                 <span style="font-weight: bold;">@context: </span>
                                 <a ng-click="networkController.showContextModal(true);"
-                                   data-toggle="tooltip"
-                                   data-placement="bottom"
-                                   title="Click here to view or modify the namespaces defined for this network.">
+                                   tooltip-placement="bottom"
+                                   tooltip="Click here to view or modify the namespaces defined for this network.">
                                     view/edit namespaces
                                 </a>
                             </span>
@@ -356,9 +355,8 @@
                                 || networkController.readOnlyChecked">
                                 <span style="font-weight: bold;">@context: </span>
                                 <a ng-click="networkController.showContextModal(false);"
-                                   data-toggle="tooltip"
-                                   data-placement="bottom"
-                                   title="Click here to view the namespaces defined for this network.">
+                                   tooltip-placement="bottom"
+                                   tooltip="Click here to view the namespaces defined for this network.">
                                     view namespaces
                                 </a>
                             </span>
@@ -811,7 +809,7 @@
             </button>
 
             <button id="saveQueryButton"
-                    ng-show="networkController.isLoggedInUser" class="actionsLabel btn btn-primary "
+                    ng-show="networkController.isLoggedInUser" class="actionsLabel btn btn-primary"
                     data-toggle="tooltip"
                     title="Save query result to your account"
                     ng-click="networkController.saveQueryResult()" >


### PR DESCRIPTION
… permission' and 'remove from my networks' flicks and are not readable.

Fixes tooltip for ‘view/edit namespace’.

Also, initializes tooltip switchToGraphViewButtonTitle = 'Switch to Graphic View' for the Graph button on query result page for queries that returned no more than queryEdgeLimitToShowGraph edges (queryEdgeLimitToShowGraph is hard-coded to 1000).