### PR TITLE
This resolves NWA-384 Tooltips Fine tuning.

### DIFF
--- a/app/scripts/controllers/manage-network-access.js
+++ b/app/scripts/controllers/manage-network-access.js
@@ -45,7 +45,10 @@ ndexApp.controller('manageNetworkAccessController',
 
 
 	$scope.showOriginalCopyNetworkShareURLTitle = function() {
-		$scope.copyNetworkShareURLTitle = 'Copy network share URL to clipboard';
+
+		$scope.copyNetworkShareURLTitle = (networkManager.network.visibility.toUpperCase() === 'PUBLIC') ?
+			'Copy network URL to clipboard' :
+			'Copy Share URL to clipboard';
 	};
 	$scope.showCopiedNetworkShareURLTitle = function() {
 		$scope.copyNetworkShareURLTitle = 'Copied';

--- a/app/scripts/controllers/network-controller.js
+++ b/app/scripts/controllers/network-controller.js
@@ -113,7 +113,10 @@ ndexApp.controller('networkController',
 
 
             $scope.showOriginalCopyNetworkShareURLTitle = function() {
-                $scope.copyNetworkShareURLTitle = 'Copy network share URL to clipboard';
+                $scope.copyNetworkShareURLTitle =
+                    (networkController.currentNetwork.visibility.toUpperCase() == 'PUBLIC') ?
+                    'Copy network URL to clipboard' :
+                    'Copy Share URL to clipboard';
             };
             $scope.showCopiedNetworkShareURLTitle = function() {
                 $scope.copyNetworkShareURLTitle = 'Copied';
@@ -3613,7 +3616,7 @@ ndexApp.controller('networkController',
                 // we set Share title only if Share option of More menu is disabled:
                 // !networkController.isAdmin
                 if (!networkController.isNetworkOwner) {
-                    $scope.shareTitle = 'Unable to Share this network: you do not own it ';
+                    $scope.shareTitle = 'You must own the network to manage its access permissions';
                 }
             };
 

--- a/app/views/directives/changePasswordModal.html
+++ b/app/views/directives/changePasswordModal.html
@@ -9,14 +9,14 @@
                 <label class="col-md-3 control-label">New Password</label>
                 <div class='col-md-7'>
                     <input name="password" type="password" class="form-control" ng-model="change.newPassword"
-                           placeholder="New Password" required>
+                           placeholder="New Password" required title="">
                 </div>
             </div>
             <div class="form-group">
                 <label class="col-md-3 control-label">Confirm Password</label>
                 <div class='col-md-7'>
                     <input name="confirmPassword" type="password" class="form-control" ng-model="change.newPasswordConfirm"
-                           placeholder="Confirm Password" required>
+                           placeholder="Confirm Password" required title="">
                 </div>
             </div>
 

--- a/app/views/directives/createGroupModal.html
+++ b/app/views/directives/createGroupModal.html
@@ -15,6 +15,7 @@
                            class="form-control"
                            placeholder="Group Name"
                            required="required"
+                           title=""
                            ng-model='group.groupName'>
                 </div>
             </div>

--- a/app/views/directives/createNetworkSetModal.html
+++ b/app/views/directives/createNetworkSetModal.html
@@ -15,6 +15,7 @@
                            class="form-control"
                            placeholder="Network Set Name"
                            required="required"
+                           title=""
                            ng-model='networkSet.networkSetName'>
                 </div>
             </div>

--- a/app/views/directives/editUserModal.html
+++ b/app/views/directives/editUserModal.html
@@ -8,11 +8,13 @@
           <div class="form-group rowWithOneLineTopPad">
             <label class="col-sm-3 control-label">Name</label>
             <div class="col-sm-4">
-              <input type="text" name="firstName" class="form-control" placeholder="First Name" ng-model='user.firstName' required>
+              <input type="text" name="firstName" class="form-control" placeholder="First Name"
+                     ng-model='user.firstName' required title="">
             </div>
 
             <div class="col-sm-4">
-              <input type="text" class="form-control" placeholder="Last Name" ng-model='user.lastName' required>
+              <input type="text" class="form-control" placeholder="Last Name"
+                     ng-model='user.lastName' required title="">
             </div>
           </div>
 
@@ -20,7 +22,8 @@
               <label class="col-sm-3 control-label">Email <span style="color:red">*</span></label>
               <div class="col-sm-8">
                   <input  type="email" name="userEmail" class="form-control"
-                          placeholder="e.g., myemail@yahoo.com" ng-model='user.emailAddress' required>
+                          placeholder="e.g., myemail@yahoo.com"
+                          ng-model='user.emailAddress' required title="">
 
                   <div ng-show="editPersonalInfo.userEmail.$error.required"
                        style="color:red; font-weight:bold; margin-top: 0.5em">E-mail is required

--- a/app/views/network.html
+++ b/app/views/network.html
@@ -103,7 +103,7 @@
                  ng-show="!networkController.successfullyQueried"
                  id="simpleQueryNetworkViewId">
 
-                <form id="frmSearchNetwork" class="form-inline pull-left">
+                <form name="queryNetworkForm" id="frmSearchNetwork" class="form-inline pull-left">
 
                     <div class="form-group">
 
@@ -115,8 +115,9 @@
                         </span>
 
 
-                        <input id="inputQueryStrId" class="form-control" type="search" ng-model="networkController.searchString"
+                        <input name="queryTermsInput" id="inputQueryStrId" class="form-control" type="search" ng-model="networkController.searchString"
                                placeholder="Query Terms (i.e., AKT1 or WNT*)" style="width:330px" required
+                               title=""
                                ng-show="!networkController.hasMultipleSubNetworks() && !disableQuery">
                     </div>
                     <div class="form-group">
@@ -137,13 +138,14 @@
                             ng-model="selectedQuery"
                             ng-options="query.name for query in networkController.queryTypes"
                             ng-disabled="networkController.hasMultipleSubNetworks() || disableQuery"
-                            required>
+                            required title="">
                         </select>
                     </div>
 
                     &nbsp;
                     <button class="btn btn-default btn-primary"
                             ng-show="!networkController.hasMultipleSubNetworks() && !disableQuery"
+                            ng-disabled="!queryNetworkForm.queryTermsInput.$valid"
                             ng-click="networkController.checkQueryNetworkAndDisplay('neighborhood')"
                             style="margin-bottom:0">Run Query
                     </button>
@@ -346,7 +348,7 @@
                                 <span style="font-weight: bold;">@context: </span>
                                 <a ng-click="networkController.showContextModal(true);"
                                    tooltip-placement="bottom"
-                                   tooltip="Click here to view or modify the namespaces defined for this network.">
+                                   tooltip="Click here to view/edit the namespaces associated with this network">
                                     view/edit namespaces
                                 </a>
                             </span>
@@ -356,7 +358,7 @@
                                 <span style="font-weight: bold;">@context: </span>
                                 <a ng-click="networkController.showContextModal(false);"
                                    tooltip-placement="bottom"
-                                   tooltip="Click here to view the namespaces defined for this network.">
+                                   tooltip="Click here to view the namespaces associated with this network">
                                     view namespaces
                                 </a>
                             </span>
@@ -514,7 +516,7 @@
                                                     <span ng-bind-html='getAttributeValue(attributeName, node[attributeName])'></span>
                                                     <br/>
                                                 </span>
-
+<!--
                                                 <span ng-switch-when="citations">
                                                     <span ng-repeat="citation in node.citations">
                                                         &nbsp;&nbsp;
@@ -522,7 +524,7 @@
                                                         <br />
                                                     </span>
                                                 </span>
-
+-->
                                                 <span ng-switch-when="ndex:internalLink">
                                                     <br>
                                                    <span style="font-size:0.9em" ng-bind-html='getAttributeValue(attributeName, node[attributeName])'></span>

--- a/app/views/partials/doiNetworkProperties.html
+++ b/app/views/partials/doiNetworkProperties.html
@@ -27,7 +27,7 @@
                 <div class="col-sm-8" style="margin-bottom: 15px;">
                     <input type="text" class="form-control" ng-change="editor.updateScore()"
                            ng-class="mainProperty.name.length > 0 ? 'competeInput': ''" type="text"
-                           placeholder="Network Name" ng-model='mainProperty.name' required>
+                           placeholder="Network Name" ng-model='mainProperty.name' required title="">
                 </div>
                 <div class="col-sm-1">
                     <div class="input-group-btn">
@@ -54,7 +54,7 @@
                     <input type="text" class="form-control" placeholder="1.0"
                            ng-change="editor.updateScore()"
                            ng-class="mainProperty.version.length > 0 ? 'competeInput': ''"
-                           ng-model='mainProperty.version' required>
+                           ng-model='mainProperty.version' required title="">
                 </div>
                 <div class="col-sm-1">
                     <div class="input-group-btn">
@@ -199,25 +199,29 @@
 
                     <select ng-show="!editor.editCustomRights" class="form-control input-sm" ng-model="property.value"
                             ng-readonly='!(editor.isAdmin || editor.canEdit) || !(editor.propertyTemplate.rights.predicateString)'
-                            ng-options="item for item in editor.rights" ng-change="editor.updateScore()" name="rights_dd" required>
+                            ng-options="item for item in editor.rights" ng-change="editor.updateScore()"
+                            name="rights_dd" required title="">
                     </select>
                 </div>
 
                 <div class="col-sm-3" style="margin-bottom: 15px;" ng-if="property.value == 'Other'">
                     <select class="form-control input-sm" ng-model="property.value"
                         ng-readonly='!(editor.isAdmin || editor.canEdit) || !(editor.propertyTemplate.rights.predicateString)'
-                        ng-options="item for item in editor.rights" ng-change="editor.updateScore()" name="rights_dd" required>
+                        ng-options="item for item in editor.rights" ng-change="editor.updateScore()"
+                            name="rights_dd" required title="">
                     </select>
                 </div>
                 <div class="col-sm-5" style="margin-bottom: 15px;" ng-if="property.value == 'Other'">
 
                     <input class="form-control input-sm" type="text"  placeholder="license title"
                             ng-model="property.rightsOther" id="doiinputrightsOther1"
-                            ng-readonly='!(editor.isAdmin || editor.canEdit) || !(editor.propertyTemplate.rights.predicateString)' required>
+                            ng-readonly='!(editor.isAdmin || editor.canEdit) || !(editor.propertyTemplate.rights.predicateString)'
+                           required title="">
 
                     <input class="form-control input-sm" type="url" placeholder="URL (http://www.mylicense.com)"
                            ng-model="property.rightsOtherURL" id="doiinputrightsOtherUrl" style="margin-top: 10px;"
-                           ng-readonly='!(editor.isAdmin || editor.canEdit) || !(editor.propertyTemplate.rights.predicateString)' required>
+                           ng-readonly='!(editor.isAdmin || editor.canEdit) || !(editor.propertyTemplate.rights.predicateString)'
+                           required title="">
                 </div>
                 <div class="col-sm-1">
                     <div class="input-group-btn">
@@ -237,7 +241,8 @@
                             class="form-control input-sm" ng-change="editor.updateScore()" type="text"
                             ng-model="property.value" id="doiinputrightsHolder"
                             ng-class="property.value.length > 0 ? 'competeInput': ''"
-                            ng-readonly='!(editor.isAdmin || editor.canEdit) || !(editor.propertyTemplate.rightsHolder.predicateString)' required>
+                            ng-readonly='!(editor.isAdmin || editor.canEdit) || !(editor.propertyTemplate.rightsHolder.predicateString)'
+                            required title="">
                 </div>
                 <div class="col-sm-1">
                     <div class="input-group-btn">
@@ -264,7 +269,8 @@
                             class="form-control input-sm" ng-change="editor.updateScore()" type="text"
                             ng-model="property.value" id="doiinputauthor"
                             ng-class="property.value.length > 0 ? 'competeInput': ''"
-                            ng-readonly='!(editor.isAdmin || editor.canEdit) || !(editor.propertyTemplate.author.predicateString)' required>
+                            ng-readonly='!(editor.isAdmin || editor.canEdit) || !(editor.propertyTemplate.author.predicateString)'
+                            required title="">
                 </div>
                 <div class="col-sm-1">
                     <div class="input-group-btn">

--- a/app/views/signInSignUpModal.html
+++ b/app/views/signInSignUpModal.html
@@ -115,11 +115,11 @@
 
                         <div class="form-group">
                             <input name="accountName" type="accountName" class="form-control" placeholder="Account Name"
-                                   required  ng-model="signIn.userName">
+                                   required title="" ng-model="signIn.userName">
                         </div>
                         <div class="form-group">
                             <input name="password" type="password" class="form-control" placeholder="Password"
-                                   required ng-model="signIn.password">
+                                   required title="" ng-model="signIn.password">
                         </div>
 
                         <div>
@@ -175,7 +175,7 @@
 
         <form role="form">
             <div class="form-group">
-                <input class="form-control" placeholder="Account Name or Email" required ng-model="forgot.accountName"/>
+                <input class="form-control" placeholder="Account Name or Email" required title="" ng-model="forgot.accountName"/>
             </div>
         </form>
         <div class='text-danger'>
@@ -212,33 +212,33 @@
                 <div class="row">
                     <div class="form-group col-md-6">
                         <input name="firstName" type="text" class="form-control" ng-model="signIn.newUser.firstName"
-                               placeholder="First Name" required>
+                               placeholder="First Name" required title="">
                     </div>
                     <div class="form-group col-md-6">
                         <input name="lastName" type="text" class="form-control" ng-model="signIn.newUser.lastName"
-                               placeholder="Last Name" required>
+                               placeholder="Last Name" required title="">
                     </div>
                 </div>
                 <div class="form-group">
                     <input name="accountName" type="text" class="form-control" ng-model="signIn.newUser.userName"
-                           placeholder="User Name (e.g. dexterpratt)" required>
+                           placeholder="User Name (e.g. dexterpratt)" required title="">
                 </div>
                 <div class="form-group">
                     <input name="email" type="email" class="form-control" ng-model="signIn.newUser.emailAddress"
-                           placeholder="Valid Email Address (required for account verification / password recovery)" required>
+                           placeholder="Valid Email Address (required for account verification / password recovery)" required title="">
                 </div>
                 <div class="form-group">
                     <input name="password" type="password" class="form-control" ng-model="signIn.newUser.password"
-                           placeholder="Password" required>
+                           placeholder="Password" required title="">
                 </div>
                 <div class="form-group">
                     <input name="confirmPassword" type="password" class="form-control"
                            ng-model="signIn.newUser.passwordConfirm"
-                           placeholder="Confirm Password" required>
+                           placeholder="Confirm Password" required title="">
                 </div>
 
                 <div class="rowWithTwoLinesTopPadAnd11EmFont">
-                    <input required ng-model="termsAndConditionsChecked" type="checkbox"> &nbsp;
+                    <input required title="" ng-model="termsAndConditionsChecked" type="checkbox"> &nbsp;
                     <label>I have read and accept the
                         <a ng-href="http://home.ndexbio.org/disclaimer-license/" target="_blank">Terms & Conditions</a>
                     </label>
@@ -311,7 +311,7 @@
             <div style="font-size: 1.2em" ng-bind-html="message"></div>
 
             <div class="rowWithTwoLinesTopPadAnd11EmFont text-center">
-                <input required ng-model="termsAndConditionsChecked" type="checkbox"> &nbsp;
+                <input required title="" ng-model="termsAndConditionsChecked" type="checkbox"> &nbsp;
                 <label>I have read and accept the
                     <a ng-href="http://home.ndexbio.org/disclaimer-license/" target="_blank">Terms & Conditions</a>
                 </label>


### PR DESCRIPTION
Changed texts of all tooltips as requested in NWA-384.
For the very first item requested in  NWA-384:

1. When hovering over on Query Terms textbox, the tooltip is the old type , like in the tables.
Please replace with new fast type.

That happened because it was a default tooltip generated by the required option
in the input filed.  To resolve this, I explicitly added title="" to
all inupt fields with required option.  That included user name adn password in
Sign In modal, all fields in Sign Up modal, change password modal, Create Group, Create Network Set,
etc.

On Network page, the Run Query button is now disabled until user provides
input in the Query Terms field.