### PR TITLE
This commit is for NWA-373 Tooltips on 'set network sample', 'upgrade…

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -147,8 +147,7 @@
 <!-- template for search bar -->
 <script type="text/ng-template" id="search_bar.html">
 
-    <form ng-show="!main.serverIsDown && (!config.requireAuthentication||main.loggedIn)"
-          ng-submit="main.search()">
+    <form ng-show="!main.serverIsDown && (!config.requireAuthentication||main.loggedIn)">
 
         <table class="table">
 
@@ -224,8 +223,15 @@
                                        ng-change="checkLengthOfSearchString()">
 
                                 <span class="input-group-btn">
-                                    <button ng-disabled="!main.searchString" type="submit" ng-click="closeModal();"
-                                            ng-class="main.searchString ? 'btn btn-primary inputHeight' : 'btn btn-default inputHeight'">
+                                    <button ng-show="main.searchString"
+                                            class="buttonWithTopAndBottomRightCornersRound btn btn-primary inputHeight"
+                                            ng-click="closeModal(); main.search()">
+                                        <span class="glyphicon glyphicon-search"></span>
+                                    </button>
+                                    <button ng-show="!main.searchString"
+                                            class="buttonWithTopAndBottomRightCornersRound actionsLabelDisabledNoMargin-btn btn btn-primary inputHeight"
+                                            tooltip="{{disabledSearchTooltip}}"
+                                            tooltip-placement="bottom">
                                         <span class="glyphicon glyphicon-search"></span>
                                     </button>
                                 </span>

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -33,6 +33,8 @@ ndexApp.controller('mainController', [ 'ndexService', 'ndexUtility', 'sharedProp
         $scope.footerHtml = window.ndexSettings.landingPageConfigServer + '/footer.html';
         //$scope.footerHtml = 'v2/footer.html';
 
+        $scope.disabledSearchTooltip = 'Please type a query term in the box to the left to enable this button.';
+
         /*
         function hideTooltip() {
             setTimeout(function() {

--- a/app/styles/ndex-angular-site.css
+++ b/app/styles/ndex-angular-site.css
@@ -1376,3 +1376,7 @@ div.featuredCollectionDescriptionArea {
 .disabledButtonWithCleanTooltip .tooltip-inner {
     max-width: 200px;
 }
+
+.buttonWithTopAndBottomRightCornersRound {
+    border-radius: 0 24px 24px 0 !important;
+}


### PR DESCRIPTION
… permission' and 'remove from my networks' flicks and are not readable.

Added a tooltip for disabled Search button on Landing page and in Search modal.
Changed the color of disabled Search button to pale blue.