### PR TITLE
This resolves NWA-403 Full indexing checkbox should be disabled if us…

### DIFF
--- a/app/scripts/controllers/edit-network-properties-controller-fixed-form.js
+++ b/app/scripts/controllers/edit-network-properties-controller-fixed-form.js
@@ -7,8 +7,7 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
 
 	//              Process the URL to get application state
     //-----------------------------------------------------------------------------------
-    var networkExternalId = $routeParams.identifier;
-    var networkId = networkExternalId;
+    var networkId = $routeParams.identifier;
     var subNetworkId = ($routeParams.subNetworkId.toLocaleLowerCase() === 'null') ? null : $routeParams.subNetworkId;
 
     //              CONTROLLER INITIALIZATIONS
@@ -16,7 +15,6 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
 
 	$scope.editor = {};
 	var editor = $scope.editor;
-    editor.networkExternalId = networkExternalId;
 	editor.propertyValuePairs = [];
 	editor.errors = [];
     editor.isAdmin = false;
@@ -632,7 +630,7 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
                         if ($scope.mainProperty.readonly) {
                             // network is read-only; make it writeable and then save properties and
                             // request a DOI
-                            ndexService.setNetworkSystemPropertiesV2(editor.networkExternalId, 'readOnly', false,
+                            ndexService.setNetworkSystemPropertiesV2(networkId, 'readOnly', false,
 
                                 function () {
                                     editor.save(requestDOI, showThesePropertiesInEmail);
@@ -658,7 +656,7 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
     };
 
     var returnToNetworkViewPage = function() {
-        $location.path('/network/' + editor.networkExternalId);
+        $location.path('/network/' + networkId);
     };
 
     editor.save = function(requestDOI, showThesePropertiesInEmail) {
@@ -760,7 +758,7 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
                 'visibility': visibility
             };
 
-            ndexService.setNetworkSummaryV2(networkExternalId, networkSummaryProperties,
+            ndexService.setNetworkSummaryV2(networkId, networkSummaryProperties,
                 function() {
 
                     $scope.isProcessing = false;
@@ -769,7 +767,7 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
                         ndexService.setNetworkSystemPropertiesV2(networkId, 'showcase', editor.showcased.state,
                             function () {
                                 if (requestDOI) {
-                                    ndexService.requestDoi(editor.networkExternalId, showThesePropertiesInEmail,
+                                    ndexService.requestDoi(networkId, showThesePropertiesInEmail,
                                         function () {
                                             returnToNetworkViewPage();
                                         },
@@ -785,7 +783,7 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
                             });
                     } else {
                         if (requestDOI) {
-                            ndexService.requestDoi(editor.networkExternalId, showThesePropertiesInEmail,
+                            ndexService.requestDoi(networkId, showThesePropertiesInEmail,
                                 function () {
                                     returnToNetworkViewPage();
                                 },
@@ -870,12 +868,13 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
 		//TODO api call
 	};
 
+/*
 	editor.addNamespace = function() {
         var namespace = {
             prefix : editor.newPrefix,
             uri : editor.newURI
         };
-		ndexService.addNamespaceToNetwork(networkExternalId, namespace,
+		ndexService.addNamespaceToNetwork(networkId, namespace,
             function() {
                 editor.namespaces.push(namespace);
                 editor.newPrefix = null;
@@ -887,14 +886,15 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
             });
 	};
 
+
 	editor.setURI = function(item) {
 		editor.newURI = item.uri;
 	};
-
+*/
     editor.refresh = $route.reload;
 
     editor.cancel = function() {
-        $location.path('/network/' + editor.networkExternalId);
+        $location.path('/network/' + networkId);
     };
 
     /* commented out by cj because we can't find usage of this variable in the app
@@ -983,7 +983,7 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
 
     //				API initializations
     //------------------------------------------------------------------------------------
-    ndexService.getNetworkSummaryV2(networkExternalId)
+    ndexService.getNetworkSummaryV2(networkId)
         .success(
             function(network) {
 
@@ -1147,9 +1147,6 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
                 editor.propertyValuePairs.push({dataType: 'string', predicateString: '', value: '', subNetworkId: subNetworkId});
 
                 editor.disableSaveChangesButton = editor.checkIfFormIsValidOnLoad();
-                var networkOwnerUUID = network.ownerUUID;
-                var loggedInUserUUID = sharedProperties.getCurrentUserId();
-                editor.isOwner = (networkOwnerUUID === loggedInUserUUID);
 
 
                 if($routeParams.doi){
@@ -1208,7 +1205,7 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
         });
 
 /*
-    ndexService.getNetworkSummaryV2(networkExternalId)
+    ndexService.getNetworkSummaryV2(networkId)
         .success(
             function (network) {
                 editor.currentNetwork = network;

--- a/app/scripts/controllers/edit-network-properties-controller-fixed-form.js
+++ b/app/scripts/controllers/edit-network-properties-controller-fixed-form.js
@@ -8,6 +8,7 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
 	//              Process the URL to get application state
     //-----------------------------------------------------------------------------------
     var networkExternalId = $routeParams.identifier;
+    var networkId = networkExternalId;
     var subNetworkId = ($routeParams.subNetworkId.toLocaleLowerCase() === 'null') ? null : $routeParams.subNetworkId;
 
     //              CONTROLLER INITIALIZATIONS
@@ -1179,7 +1180,6 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
         );
 
     var userId = sharedProperties.getCurrentUserId();
-    var networkId = networkExternalId;
     var directonly = false;
 
     ndexService.getUserPermissionForNetworkV2(userId, networkId, directonly,
@@ -1196,6 +1196,10 @@ ndexApp.controller('editNetworkPropertiesFixedFormController',
                 }
                 if (myMembership === 'READ') {
                     editor.canRead = true;
+                }
+                if (!editor.isAdmin) {
+                    $scope.disabledVisibilityTooltip = 'Only network owners can change network Visibility';
+                    $scope.disabledFullIndexTooltip  = 'Only network owners can change Full Index option';
                 }
             }
         },

--- a/app/views/partials/mainNetworkProperties.html
+++ b/app/views/partials/mainNetworkProperties.html
@@ -80,7 +80,7 @@
                 <label class="col-sm-3 control-label">visibility</label>
                 <div class="col-sm-5" style="margin-bottom: 15px;">
 
-                    <span ng-show="editor.isOwner">
+                    <span ng-show="editor.isAdmin">
 
                         <div ng-show="checkNameDescriptionVersion()">
                             <select class="form-control minwidth170"
@@ -107,7 +107,7 @@
                         </div>
                     </span>
 
-                    <span ng-show="!editor.isOwner" tooltip="{{disabledVisibilityTooltip}}">
+                    <span ng-show="!editor.isAdmin" tooltip="{{disabledVisibilityTooltip}}">
                     <select class="form-control minwidth170" ng-model='editor.visibilityIndex' disabled>
                             <option value='PUBLIC' ng-selected='editor.visibilityIndex ==  "PUBLIC"'>Public </option>
                             <option value='PUBLIC_NOT_INDEXED' ng-selected='editor.visibilityIndex ==  "PUBLIC_NOT_INDEXED"'>Public (not searchable)</option>

--- a/app/views/partials/mainNetworkProperties.html
+++ b/app/views/partials/mainNetworkProperties.html
@@ -107,9 +107,8 @@
                         </div>
                     </span>
 
-                    <span ng-show="!editor.isOwner">
-                        <select class="form-control minwidth170" ng-model='editor.visibilityIndex'
-                                title="Only network owners can change network Visibility" disabled>
+                    <span ng-show="!editor.isOwner" tooltip="{{disabledVisibilityTooltip}}">
+                    <select class="form-control minwidth170" ng-model='editor.visibilityIndex' disabled>
                             <option value='PUBLIC' ng-selected='editor.visibilityIndex ==  "PUBLIC"'>Public </option>
                             <option value='PUBLIC_NOT_INDEXED' ng-selected='editor.visibilityIndex ==  "PUBLIC_NOT_INDEXED"'>Public (not searchable)</option>
                             <option value='PRIVATE' ng-selected='editor.visibilityIndex ==  "PRIVATE"'>Private </option>
@@ -161,23 +160,24 @@
                 <div class="col-sm-3" ng-show="(mainProperty.visibility == 'PUBLIC' || mainProperty.visibility == 'PRIVATE')"
                      style="margin-top: 5px; padding-right:0">
 
-                    <span ng-show="checkNameDescriptionVersion()">
-                        <a ng-click="showFullIndexAdvisory();"
-                           style="text-decoration: none; color: #656565; white-space: nowrap;">
+                    <div ng-if="editor.isAdmin">
+                        <span ng-show="checkNameDescriptionVersion()">
+                            <a ng-click="showFullIndexAdvisory();"
+                               style="text-decoration: none; color: #656565; white-space: nowrap;">
 
-                            <span class="fa-stack" >
-                                <i class="fa fa-square-o fa-stack-2x"></i>
-                                <i ng-show="editor.fullIndexed.state" class="fa fa-check fa-stack-1x"></i>
-                            </span>
+                                <span class="fa-stack" >
+                                    <i class="fa fa-square-o fa-stack-2x"></i>
+                                    <i ng-show="editor.fullIndexed.state" class="fa fa-check fa-stack-1x"></i>
+                                </span>
 
-                            <span style="font-size: 15px;">
-                                Full Index
-                            </span>
-                        </a>
-                    </span>
+                                <span style="font-size: 15px;">
+                                    Full Index
+                                </span>
+                            </a>
+                        </span>
 
-                    <span ng-show="!checkNameDescriptionVersion()" ng-click="doNothingOnMouseClick()"
-                          tooltip="{{fillInNameDescriptionVersionFirst}}">
+                        <span ng-show="!checkNameDescriptionVersion()" ng-click="doNothingOnMouseClick()"
+                              tooltip="{{fillInNameDescriptionVersionFirst}}">
 
                             <span class="fa-stack" >
                                 <i class="fa fa-square-o fa-stack-2x fa-disabled"></i>
@@ -187,19 +187,27 @@
                             <span class="fa-disabled" style="font-size: 15px;">
                                 Full Index
                             </span>
-
-
-                    </span>
-
-
-                        <!--
-                        <span data-toggle="tooltip" title="{{fullIndexToolTip}}"
-                           style="cursor: pointer; color: #428bca;"
-                           target="_blank" ng-init="setToolTips()">
-                            <i class="fa fa-info-circle"></i>
                         </span>
-                        -->
+                    </div>
+
+
+                    <div ng-if="!editor.isAdmin">
+                        <span ng-click="doNothingOnMouseClick()">
+
+                            <span class="fa-stack" tooltip="{{disabledFullIndexTooltip}}">
+                                <i class="fa fa-square-o fa-stack-2x fa-disabled"></i>
+                                <i ng-show="editor.fullIndexed.state" class="fa fa-check fa-stack-1x fa-disabled"></i>
+                            </span>
+
+                            <span class="fa-disabled" tooltip="{{disabledFullIndexTooltip}}" style="font-size: 15px;">
+                                Full Index
+                            </span>
+                        </span>
+                    </div>
+
                 </div>
+
+
 
                 <div class="col-sm-1" ng-show="(mainProperty.visibility == 'PUBLIC' || mainProperty.visibility == 'PRIVATE')"
                      style="margin-top: 5px; padding-left: 0">


### PR DESCRIPTION
…er is not owner of a network.

Modified edit-network-properties-controller to initialize $scope.disabledVisibilityTooltip and
$scope.disabledFullIndexTooltip in case user is not admin of the network (s)he edits.

In mainNetworkProperties view, for Full Index we check if user is admin.  If no, then we disabled
this Full Index checkbox and pop a tooltip disabledFullIndexTooltip when user hovers over it.

Fixed tooltip for disabled Visibility - before if user couldn't change visibility because (s)he
wasn't an admin of this network, we showed a "slow" title description; now we show a "fast" tooltip description.

Fixed "used before initialized warning" by placing
var networkId = networkExternalId;
at the top of the controller.