### PR TITLE
This resolves NWA-400 Network lost background when switching back fro…

### DIFF
--- a/app/scripts/controllers/network-controller.js
+++ b/app/scripts/controllers/network-controller.js
@@ -1059,7 +1059,10 @@ ndexApp.controller('networkController',
                         var ctx = backgroundLayer.getCanvas().getContext("2d");
                         ctx.fillStyle = cxBGColor;
                         ctx.fillRect(0, 0, canvas.width, canvas.height);
-                        //networkController.bgColor = cxBGColor;
+                        networkController.bgColor = cxBGColor;
+                    } else {
+                        // no background color for Canvas - set to default
+                        resetBackgroundColor();
                     }
 
                     var cyAnnotationService = new cyannotationCx2js.CxToCyCanvas(cyService);
@@ -1256,7 +1259,7 @@ ndexApp.controller('networkController',
                 } else {
                     cyStyle = cyService.cyStyleFromNiceCX(cxNetwork, attributeNameMap);
                 }
-                resetBackgroundColor();
+
                 // networkController.prettyStyle added for debugging -- remove/comment out when done
                 //networkController.prettyStyle = JSON.stringify(cyStyle, null, 2);
 
@@ -4178,8 +4181,7 @@ ndexApp.controller('networkController',
                                     networkController.canEdit ||
                                     networkController.canRead || accesskey)
                                 {
-                                        resetBackgroundColor();
-                                        getNetworkAndDisplay(networkExternalId,drawCXNetworkOnCanvas);
+                                    getNetworkAndDisplay(networkExternalId, drawCXNetworkOnCanvas);
                                 }
                             });
 
@@ -4278,7 +4280,7 @@ ndexApp.controller('networkController',
                         //getCytoscapeAndCyRESTVersions();
 
 
-                        resetBackgroundColor();
+                        //resetBackgroundColor();
                         drawCXNetworkOnCanvas(niceCX, false);
 
                         networkController.readOnlyChecked = networkController.currentNetwork.isReadOnly;


### PR DESCRIPTION
…m table view.

In initCyGraphFromCyjsComponents() we need to set networkController.bgColor in case
cxNetwork has background color:

networkController.bgColor = cxBGColor

This networkController.bgColor is used in network view CSS on the DIV
containing cytoscape.js canvas that renders the network.

resetBackgroundColor() is now only called from one place, from initCyGraphFromCyjsComponents()
in case no background color is found in cxNetwork.