### PR TITLE
This commit resolves NWA-400 Network lost background when switching b…

### DIFF
--- a/app/scripts/controllers/network-controller.js
+++ b/app/scripts/controllers/network-controller.js
@@ -290,15 +290,9 @@ ndexApp.controller('networkController',
 
             $scope.showDeleteDOILink = false;
 
-
-            //networkController.prettyStyle = "no style yet";
-            //networkController.prettyVisualProperties = "nothing yet";
-            var resetBackgroundColor = function () {
-                //background color needs to be transparent so that multiple canvases can be used for
-                //annotation rendering.
-                networkController.bgColor = 'rgba(0,0,0,0)';
-                //old default color was '#8fbdd7';
-            };
+            // default background color for the Cytsocape.js Graph mode;
+            var defaultBackgroundColor = 'rgba(0,0,0,0)';
+            networkController.bgColor  = defaultBackgroundColor;
 
             var localNetwork;
 
@@ -1050,20 +1044,26 @@ ndexApp.controller('networkController',
                         console.log(e);
                     }
 
+                    // cxBGColor is used as fill color for Canvas
+                    // cyService.cyBackgroundColorFromNiceCX returns color as string, or undefined
                     var cxBGColor = cyService.cyBackgroundColorFromNiceCX(cxNetwork);
-                    if (cxBGColor) {
-                        var backgroundLayer = cy.cyCanvas({
-                            zIndex: -2
-                        });
-                        var canvas = backgroundLayer.getCanvas();
-                        var ctx = backgroundLayer.getCanvas().getContext("2d");
+
+                    // see if cxNetwork has background color; if no - we will use default.
+                    if (!cxBGColor) {
+                        cxBGColor = defaultBackgroundColor;
+                    }
+
+                    var backgroundLayer = cy.cyCanvas({
+                        zIndex: -2
+                    });
+
+                    var canvas = backgroundLayer.getCanvas();
+                    var ctx = backgroundLayer.getCanvas().getContext("2d");
+
+                    cy.on("render cyCanvas.resize", function() {
                         ctx.fillStyle = cxBGColor;
                         ctx.fillRect(0, 0, canvas.width, canvas.height);
-                        networkController.bgColor = cxBGColor;
-                    } else {
-                        // no background color for Canvas - set to default
-                        resetBackgroundColor();
-                    }
+                    });
 
                     var cyAnnotationService = new cyannotationCx2js.CxToCyCanvas(cyService);
                     cyAnnotationService.drawAnnotationsFromNiceCX(cy, cxNetwork);
@@ -4280,7 +4280,6 @@ ndexApp.controller('networkController',
                         //getCytoscapeAndCyRESTVersions();
 
 
-                        //resetBackgroundColor();
                         drawCXNetworkOnCanvas(niceCX, false);
 
                         networkController.readOnlyChecked = networkController.currentNetwork.isReadOnly;

--- a/app/scripts/controllers/network-controller.js
+++ b/app/scripts/controllers/network-controller.js
@@ -12,7 +12,7 @@ ndexApp.controller('networkController',
             
             var cxNetworkUtils = new cytoscapeCx2js.CyNetworkUtils();
             var cyService = new cytoscapeCx2js.CxToJs(cxNetworkUtils);
-            
+
             const defaultStyle = [  {
                 "selector": "node",
                 "css": {
@@ -289,10 +289,6 @@ ndexApp.controller('networkController',
             $scope.showAdvancedQuery = true;
 
             $scope.showDeleteDOILink = false;
-
-            // default background color for the Cytsocape.js Graph mode;
-            var defaultBackgroundColor = 'rgba(0,0,0,0)';
-            networkController.bgColor  = defaultBackgroundColor;
 
             var localNetwork;
 
@@ -1050,7 +1046,8 @@ ndexApp.controller('networkController',
 
                     // see if cxNetwork has background color; if no - we will use default.
                     if (!cxBGColor) {
-                        cxBGColor = defaultBackgroundColor;
+                        // default background color for the Cytsocape.js Graph mode;
+                        cxBGColor = 'rgba(0, 0, 0, 0)';
                     }
 
                     var backgroundLayer = cy.cyCanvas({

--- a/app/styles/ndex-angular-site.css
+++ b/app/styles/ndex-angular-site.css
@@ -773,7 +773,6 @@ ul.ndex-nav-pills > li > a:hover {
     margin:0 auto;
 
     /*height: 90vh;*/
-    background-color: #eee;
     position: relative;
 }
 

--- a/app/views/network.html
+++ b/app/views/network.html
@@ -16,7 +16,7 @@
 
             <div id="spinnerId"></div>
 
-            <div class="cytoscapeCanvas" id="cytoscape-canvas" ng-style="{background: networkController.bgColor}"
+            <div class="cytoscapeCanvas" id="cytoscape-canvas"
                  ng-show="currentView == 'Graphic'">
             </div>
 


### PR DESCRIPTION
…ack from table view

The default background color of  Cytoscape Graph is now always set to rgba(0,0,0,0)’;

In initCyGraphFromCyjsComponents() we create Canvas and set it under the Cytoscape graph.
To set the color of this canvas, we try to get it background color from our network in cx:
If it is present, it is set as background color (fillStyle)
If there is no background color in the network, we use the default rgba(0,0,0,0).

Important: in order to keep  background color of Canvas when switching from Graph view and back, and resizing the window,
 we need to catch the render and cyCanvas.resize events, re-set fillStyle and re-fill:

cy.on("render cyCanvas.resize", function() {
    ctx.fillStyle = cxBGColor;
    ctx.fillRect(0, 0, canvas.width, canvas.height);
});

For more info and sample code:
https://github.com/classcraft/cytoscape.js-canvas
https://github.com/classcraft/cytoscape.js-canvas/blob/master/demo.html