### PR TITLE
Bug fix. In table view when clicking on a list value cell, the title of

### DIFF
--- a/app/scripts/controllers/network-controller.js
+++ b/app/scripts/controllers/network-controller.js
@@ -2746,11 +2746,12 @@ ndexApp.controller('networkController',
                 networkController.genericInfoModal(title, attributeValue);
             };
 
-            //TODO: review what the differences are between this function and the function above. -- cj
-            $scope.showMoreAttributesInTable = function(attributeName, attributeObj) {
+            // The only difference between this and -- cj
 
-                var title;
-                var typeOfAttributeName = typeof attributeName;
+            $scope.showMoreAttributesInTable = function(attributeDisplayName, attributeObj) {
+
+             //   var title = attributeDisplayName;
+          /*      var typeOfAttributeName = typeof attributeName;
 
                 if ((typeOfAttributeName === 'object') && (Array.isArray(attributeObj))) {
 
@@ -2778,7 +2779,7 @@ ndexApp.controller('networkController',
                     }
                 } else {
                     title = attributeName + ':';
-                }
+                } */
 
                 var attributeValue = '';
 
@@ -2807,7 +2808,7 @@ ndexApp.controller('networkController',
                     }
                 }
 
-                networkController.genericInfoModal(title, attributeValue);
+                networkController.genericInfoModal(attributeDisplayName + ":", attributeValue);
             };
 
             networkController.contextModal = function(title, message, isEdit)

--- a/app/views/gridTemplates/showCellContentsInNetworkTable.html
+++ b/app/views/gridTemplates/showCellContentsInNetworkTable.html
@@ -6,7 +6,7 @@
 
     <span ng-if="grid.appScope.getNumOfAttributes(COL_FIELD) > 1">
         <div class="text-center">
-            <a ng-click="grid.appScope.showMoreAttributesInTable(row, COL_FIELD)">
+            <a ng-click="grid.appScope.showMoreAttributesInTable(col.displayName, COL_FIELD)">
                 {{grid.appScope.getNumOfAttributes(COL_FIELD)}}
             </a>
         </div>


### PR DESCRIPTION
the pop up was using the internal field name. It should use the display
name of the column. The old implementation of the showMoreAttributesInTable
function had a bug that it can pick a wrong attribute name if the row has
more than one columns that have lists as value and the size of the list
is the same.